### PR TITLE
Add EditorConfig file defining indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[css/jquery.lightbox.js]
+indent_style = tab
+
+[css/jquery.lightbox.css]
+indent_style = tab
+
+[demo/*]
+indent_style = tab
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This `.editorconfig` file defines the indentation style used in this project.

[EditorConfig](http://editorconfig.org) is a file format for defining programming conventions in shared projects.  Currently there are plugins available for [many popular text editors](http://editorconfig.org/#download) and plugin development is planned for more editors and IDEs.

With this `.editorconfig` file, contributors with an EditorConfig plugin instaled will find adhering to your indentation style more natural (especially those that don't normally use hard tabs for indentation).
## 

I co-created the EditorConfig project last year.  We greatly appreciate feedback on the project.  If you have ideas or concerns about the project I would love to hear them.
